### PR TITLE
Preserve leading whitespace characters on config update

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ $config_transformer->update( 'constant', 'FOO', 'bar', array( 'add' => false ) )
 
 ### Parsing configs
 
-Constants: https://regex101.com/r/6AeNGP/2
+Constants: https://regex101.com/r/6AeNGP/3
 
-Variables: https://regex101.com/r/cSLZZz/2
+Variables: https://regex101.com/r/cSLZZz/3
 
 ### Editing in place
 

--- a/src/WPConfigTransformer.php
+++ b/src/WPConfigTransformer.php
@@ -194,7 +194,11 @@ class WPConfigTransformer {
 			$new_src      = implode( '', $new_parts );
 		}
 
-		$contents = preg_replace( sprintf( '/(?<=^|;|<\?php\s|<\?\s)%s/m', preg_quote( $old_src, '/' ) ), str_replace( '$', '\$', $new_src ), $this->wp_config_src );
+		$contents = preg_replace(
+			sprintf( '/(?<=^|;|<\?php\s|<\?\s)(\s*?)%s/m', preg_quote( trim( $old_src ), '/' ) ),
+			'$1' . str_replace( '$', '\$', trim( $new_src ) ),
+			$this->wp_config_src
+		);
 
 		return $this->save( $contents );
 	}

--- a/tests/fixtures/block-data.txt
+++ b/tests/fixtures/block-data.txt
@@ -31,6 +31,11 @@ DEFINE( 'TEST_CONST_#', 'oldvalue' );
 ---
 DEFINE  ('TEST_CONST_#'    ,'oldvalue'   );
 ---
+define( 'TEST_CONST_#', 'oldvalue' ); // Some comment
+---
+echo null; // Some comment before
+define( 'TEST_CONST_#', 'oldvalue' ); // Some comment
+---
 define( 'TEST_CONST_#', 'oldvalue', false );
 ---
 define(    'TEST_CONST_#'   ,    'oldvalue'  , false  );
@@ -93,3 +98,8 @@ $test_var_#   ='oldvalue'    ;
 ---
 $test_var_#=
 'oldvalue' ;
+---
+$test_var_# = 'oldvalue'; // Some comment
+---
+echo null; // Some comment before
+$test_var_# = 'oldvalue'; // Some comment


### PR DESCRIPTION
Fixes https://github.com/wp-cli/config-command/issues/57