### PR TITLE
Use real config filename in Exception messages

### DIFF
--- a/src/WPConfigTransformer.php
+++ b/src/WPConfigTransformer.php
@@ -35,12 +35,14 @@ class WPConfigTransformer {
 	 * @param string $wp_config_path Path to a wp-config.php file.
 	 */
 	public function __construct( $wp_config_path ) {
+		$basename = basename( $wp_config_path );
+
 		if ( ! file_exists( $wp_config_path ) ) {
-			throw new Exception( 'wp-config.php file does not exist.' );
+			throw new Exception( "{$basename} does not exist." );
 		}
 
 		if ( ! is_writable( $wp_config_path ) ) {
-			throw new Exception( 'wp-config.php file is not writable.' );
+			throw new Exception( "{$basename} is not writable." );
 		}
 
 		$this->wp_config_path = $wp_config_path;
@@ -61,7 +63,7 @@ class WPConfigTransformer {
 		$wp_config_src = file_get_contents( $this->wp_config_path );
 
 		if ( ! trim( $wp_config_src ) ) {
-			throw new Exception( 'wp-config.php file is empty.' );
+			throw new Exception( 'Config file is empty.' );
 		}
 
 		$this->wp_config_src = $wp_config_src;
@@ -89,7 +91,7 @@ class WPConfigTransformer {
 		$wp_config_src = file_get_contents( $this->wp_config_path );
 
 		if ( ! trim( $wp_config_src ) ) {
-			throw new Exception( 'wp-config.php file is empty.' );
+			throw new Exception( 'Config file is empty.' );
 		}
 
 		$this->wp_config_src = $wp_config_src;
@@ -329,7 +331,7 @@ class WPConfigTransformer {
 	 */
 	protected function save( $contents ) {
 		if ( ! trim( $contents ) ) {
-			throw new Exception( 'Cannot save the wp-config.php file with empty contents.' );
+			throw new Exception( 'Cannot save the config file with empty contents.' );
 		}
 
 		if ( $contents === $this->wp_config_src ) {
@@ -339,7 +341,7 @@ class WPConfigTransformer {
 		$result = file_put_contents( $this->wp_config_path, $contents, LOCK_EX );
 
 		if ( false === $result ) {
-			throw new Exception( 'Failed to update the wp-config.php file.' );
+			throw new Exception( 'Failed to update the config file.' );
 		}
 
 		return true;

--- a/tests/0-SetupTest.php
+++ b/tests/0-SetupTest.php
@@ -6,7 +6,7 @@ class SetupTest extends TestCase
 {
 	/**
 	 * @expectedException        Exception
-	 * @expectedExceptionMessage wp-config.php file does not exist.
+	 * @expectedExceptionMessage wp-config-missing.php does not exist.
 	 */
 	public function testFileMissing()
 	{
@@ -15,7 +15,7 @@ class SetupTest extends TestCase
 
 	/**
 	 * @expectedException        Exception
-	 * @expectedExceptionMessage wp-config.php file is not writable.
+	 * @expectedExceptionMessage wp-config-not-writable.php is not writable.
 	 */
 	public function testFileNotWritable()
 	{
@@ -25,7 +25,7 @@ class SetupTest extends TestCase
 
 	/**
 	 * @expectedException        Exception
-	 * @expectedExceptionMessage wp-config.php file is empty.
+	 * @expectedExceptionMessage Config file is empty.
 	 */
 	public function testFileEmpty()
 	{


### PR DESCRIPTION
This library does not require the file to always be named `wp-config.php`. Exception messages should use the real filename that was used to instantiate the class.