### PR TITLE
create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+* text=auto
+
+.gitattributes export-ignore
+.gitignore export-ignore
+composer.lock export-ignore
+.travis.yml export-ignore
+/ci export-ignore
+/tests export-ignore
+phpunit.xml.dist export-ignore
+phpunit.xml.dist export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,7 +2,6 @@
 
 .gitattributes export-ignore
 .gitignore export-ignore
-composer.lock export-ignore
 .travis.yml export-ignore
 /ci export-ignore
 /tests export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,5 +5,5 @@
 .travis.yml export-ignore
 /ci export-ignore
 /tests export-ignore
-phpunit.xml.dist export-ignore
+phpcs.xml.dist export-ignore
 phpunit.xml.dist export-ignore


### PR DESCRIPTION
How about adding a .gitattributes file so including the project in composer can not include all the non-essential files?