### PR TITLE
fix new_src substitution

### DIFF
--- a/src/WPConfigTransformer.php
+++ b/src/WPConfigTransformer.php
@@ -195,7 +195,7 @@ class WPConfigTransformer {
 			$new_parts[1] = str_replace( $old_value, $new_value, $new_parts[1] ); // Only edit the value part.
 			$new_src      = implode( '', $new_parts );
 		}
-		$safe_new_src = preg_replace( '/(^\$|^(?:\\\\\\\\)+|[^\\\\](?:\\\\\\\\)+|[^\\\\])\$/m', '$1\\\\$', trim( $new_src ) );
+		$safe_new_src = preg_replace( '/([\\\\$])/m', '\\\\$1', trim( $new_src ) );
 
 		$contents = preg_replace(
 			sprintf( '/(?<=^|;|<\?php\s|<\?\s)(\s*?)%s/m', preg_quote( trim( $old_src ), '/' ) ),

--- a/src/WPConfigTransformer.php
+++ b/src/WPConfigTransformer.php
@@ -195,7 +195,7 @@ class WPConfigTransformer {
 			$new_parts[1] = str_replace( $old_value, $new_value, $new_parts[1] ); // Only edit the value part.
 			$new_src      = implode( '', $new_parts );
 		}
-		$safe_new_src = preg_replace('/(^\$|^(?:\\\\\\\\)+|[^\\\\](?:\\\\\\\\)+|[^\\\\])\$/m', '$1\\\\$', trim($new_src));
+		$safe_new_src = preg_replace( '/(^\$|^(?:\\\\\\\\)+|[^\\\\](?:\\\\\\\\)+|[^\\\\])\$/m', '$1\\\\$', trim( $new_src ) );
 
 		$contents = preg_replace(
 			sprintf( '/(?<=^|;|<\?php\s|<\?\s)(\s*?)%s/m', preg_quote( trim( $old_src ), '/' ) ),

--- a/src/WPConfigTransformer.php
+++ b/src/WPConfigTransformer.php
@@ -195,10 +195,14 @@ class WPConfigTransformer {
 			$new_parts[1] = str_replace( $old_value, $new_value, $new_parts[1] ); // Only edit the value part.
 			$new_src      = implode( '', $new_parts );
 		}
+		
+		// regex: (^\$|^(?:\\\\)+|[^\\](?:\\\\)+|[^\\])\$
+		// subst: $1\\$
+		$safe_new_src = preg_replace('/(^\$|^(?:\\\\\\\\)+|[^\\\\](?:\\\\\\\\)+|[^\\\\])\$/m', '$1\\\\$', trim($new_src));
 
 		$contents = preg_replace(
 			sprintf( '/(?<=^|;|<\?php\s|<\?\s)(\s*?)%s/m', preg_quote( trim( $old_src ), '/' ) ),
-			'$1' . str_replace( '$', '\$', trim( $new_src ) ),
+			'$1' . $safe_new_src,
 			$this->wp_config_src
 		);
 

--- a/src/WPConfigTransformer.php
+++ b/src/WPConfigTransformer.php
@@ -196,8 +196,8 @@ class WPConfigTransformer {
 			$new_src      = implode( '', $new_parts );
 		}
 		
-		// regex: (^\$|^(?:\\\\)+|[^\\](?:\\\\)+|[^\\])\$
-		// subst: $1\\$
+		// regex: (^\$|^(?:\\\\)+|[^\\](?:\\\\)+|[^\\])\$ .
+		// subst: $1\\$ .
 		$safe_new_src = preg_replace('/(^\$|^(?:\\\\\\\\)+|[^\\\\](?:\\\\\\\\)+|[^\\\\])\$/m', '$1\\\\$', trim($new_src));
 
 		$contents = preg_replace(

--- a/src/WPConfigTransformer.php
+++ b/src/WPConfigTransformer.php
@@ -195,9 +195,6 @@ class WPConfigTransformer {
 			$new_parts[1] = str_replace( $old_value, $new_value, $new_parts[1] ); // Only edit the value part.
 			$new_src      = implode( '', $new_parts );
 		}
-		
-		// regex: (^\$|^(?:\\\\)+|[^\\](?:\\\\)+|[^\\])\$ .
-		// subst: $1\\$ .
 		$safe_new_src = preg_replace('/(^\$|^(?:\\\\\\\\)+|[^\\\\](?:\\\\\\\\)+|[^\\\\])\$/m', '$1\\\\$', trim($new_src));
 
 		$contents = preg_replace(

--- a/src/WPConfigTransformer.php
+++ b/src/WPConfigTransformer.php
@@ -195,7 +195,7 @@ class WPConfigTransformer {
 			$new_parts[1] = str_replace( $old_value, $new_value, $new_parts[1] ); // Only edit the value part.
 			$new_src      = implode( '', $new_parts );
 		}
-		$safe_new_src = preg_replace( '/([\\\\$])/m', '\\\\$1', trim( $new_src ) );
+		$safe_new_src = preg_replace( '/(^\$|^(?:\\\\\\\\)+|[^\\\\](?:\\\\\\\\)+|[^\\\\])\$/m', '$1\\\\$', trim( $new_src ) );
 
 		$contents = preg_replace(
 			sprintf( '/(?<=^|;|<\?php\s|<\?\s)(\s*?)%s/m', preg_quote( trim( $old_src ), '/' ) ),


### PR DESCRIPTION
In the case of the char `$` preceded by `\`
the substitution didn't work correctly.

I have improved the simple addition of `\`
With a regex that adds `\` in case the character `$` is not preceded by an odd number of `\`

Code example

```php
$dbpass = '$3_\\\$56[Plac\\$1eholder]xxx$10';
$confTransformer->update('constant', 'DB_PASSWORD', $dbpass, array('raw' => false));
```

---------------
These bugs we can find them because we use this library in the Duplicator plugin and we are dealing with millions of different passwords with every possible character sequence.