### PR TITLE
Add a way to add to EOF

### DIFF
--- a/src/WPConfigTransformer.php
+++ b/src/WPConfigTransformer.php
@@ -4,6 +4,10 @@
  * Transforms a wp-config.php file.
  */
 class WPConfigTransformer {
+	/**
+	 * Append to end of file
+	 */
+	const ANCHOR_EOF = 'EOF';
 
 	/**
 	 * Path to the wp-config.php file.
@@ -140,13 +144,17 @@ class WPConfigTransformer {
 		$separator = (string) $separator;
 		$placement = (string) $placement;
 
-		if ( false === strpos( $this->wp_config_src, $anchor ) ) {
-			throw new Exception( 'Unable to locate placement anchor.' );
-		}
+		if ( self::ANCHOR_EOF === $anchor ) {
+			$contents = $this->wp_config_src . $this->normalize( $type, $name, $this->format_value( $value, $raw ) );
+		} else {
+			if ( false === strpos( $this->wp_config_src, $anchor ) ) {
+				throw new Exception( 'Unable to locate placement anchor.' );
+			}
 
-		$new_src  = $this->normalize( $type, $name, $this->format_value( $value, $raw ) );
-		$new_src  = ( 'after' === $placement ) ? $anchor . $separator . $new_src : $new_src . $separator . $anchor;
-		$contents = str_replace( $anchor, $new_src, $this->wp_config_src );
+			$new_src  = $this->normalize( $type, $name, $this->format_value( $value, $raw ) );
+			$new_src  = ( 'after' === $placement ) ? $anchor . $separator . $new_src : $new_src . $separator . $anchor;
+			$contents = str_replace( $anchor, $new_src, $this->wp_config_src );
+		}
 
 		return $this->save( $contents );
 	}

--- a/tests/2-UpdateTest.php
+++ b/tests/2-UpdateTest.php
@@ -251,4 +251,15 @@ class UpdateTest extends TestCase
 		$this->assertFalse( defined( 'TEST_CONST_UPDATE_NO_ADD_MISSING' ), 'TEST_CONST_UPDATE_NO_ADD_MISSING' );
 		$this->assertFalse( isset( $test_var_update_no_add_missing ), '$test_var_update_no_add_missing' );
 	}
+
+	public function testAddConstantWithoutAnchor()
+	{
+		$name = 'TEST_CONST_ADD_EXISTS_NO_ANCHOR';
+		$this->assertTrue( self::$config_transformer->add( 'constant', $name, 'foo', array ( 'anchor' => WPConfigTransformer::ANCHOR_EOF ), $name ) );
+		$this->assertTrue( self::$config_transformer->exists( 'constant', $name ), $name );
+		$this->assertFalse( self::$config_transformer->add( 'constant', $name, 'bar' ), $name );
+
+		$config_data = file( self::$test_config_path );
+		$this->assertContains( $name, end($config_data) );
+	}
 }


### PR DESCRIPTION
This is a fix for #10. However, instead of using
```php
[ 'anchor' => WPConfigTransformer::NO_ANCHOR ]
```
I suggest to use
```php
[ 'anchor' => WPConfigTransformer::ANCHOR_EOF ]
```
With this name you know where it will be placed right away.