### PR TITLE
CI: fix PHPCS workflow

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     "require-dev": {
         "composer/composer": ">=1.5.6 <1.7.0 || ^1.7.1 || ^2.0.0",
         "phpunit/phpunit": "^6.5.5 || ^7.0.0",
-        "wp-coding-standards/wpcs": "^0.14.0 || ^1.0.0 || ^2.0.0"
+        "wp-coding-standards/wpcs": "^0.14.0 || ^1.0.0 || ^2.0.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1"
     },
     "autoload": {
         "files": [ "src/WPConfigTransformer.php" ]


### PR DESCRIPTION
External PHPCS standards need to be registered with PHPCS, this Composer plugin sorts that out ;-)

(saw your message in Slack)