### PR TITLE
Avoid test failure with `assertNotSame` instead of `assertNotEquals`

### DIFF
--- a/tests/2-UpdateTest.php
+++ b/tests/2-UpdateTest.php
@@ -377,12 +377,12 @@ class UpdateTest extends TestCase {
 			// Raw Constants
 			$name = "TEST_CONST_UPDATE_RAW_{$d}";
 			$this->assertTrue( defined( $name ), $name );
-			$this->assertNotEquals( 'oldvalue', constant( $name ), $name );
+			$this->assertNotSame( 'oldvalue', constant( $name ), $name );
 			$this->assertEquals( $data, constant( $name ), $name );
 			// Raw Variables
 			$name = "test_var_update_raw_{$d}";
 			$this->assertTrue( ( isset( ${$name} ) || is_null( ${$name} ) ), "\${$name}" );
-			$this->assertNotEquals( 'oldvalue', ${$name}, "\${$name}" );
+			$this->assertNotSame( 'oldvalue', ${$name}, "\${$name}" );
 			$this->assertEquals( $data, ${$name}, "\${$name}" );
 		}
 
@@ -390,12 +390,12 @@ class UpdateTest extends TestCase {
 			// String Constants
 			$name = "TEST_CONST_UPDATE_STRING_{$d}";
 			$this->assertTrue( defined( $name ), $name );
-			$this->assertNotEquals( 'oldvalue', constant( $name ), $name );
+			$this->assertNotSame( 'oldvalue', constant( $name ), $name );
 			$this->assertEquals( $data, constant( $name ), $name );
 			// String Variables
 			$name = "test_var_update_string_{$d}";
 			$this->assertTrue( ( isset( ${$name} ) || is_null( ${$name} ) ), "\${$name}" );
-			$this->assertNotEquals( 'oldvalue', ${$name}, "\${$name}" );
+			$this->assertNotSame( 'oldvalue', ${$name}, "\${$name}" );
 			$this->assertEquals( $data, ${$name}, "\${$name}" );
 		}
 

--- a/tests/3-BlockTest.php
+++ b/tests/3-BlockTest.php
@@ -118,14 +118,14 @@ class BlockTest extends TestCase {
 				eval( "\$data = $data;" ); // phpcs:ignore Squiz.PHP.Eval.Discouraged
 				$name = "TEST_CONST_BLOCK_{$b}_RAW_{$d}";
 				$this->assertTrue( defined( $name ), $name );
-				$this->assertNotEquals( 'oldvalue', constant( $name ), $name );
+				$this->assertNotSame( 'oldvalue', constant( $name ), $name );
 				$this->assertEquals( $data, constant( $name ), $name );
 			}
 			// Strings
 			foreach ( self::$string_data as $d => $data ) {
 				$name = "TEST_CONST_BLOCK_{$b}_STRING_{$d}";
 				$this->assertTrue( defined( $name ), $name );
-				$this->assertNotEquals( 'oldvalue', constant( $name ), $name );
+				$this->assertNotSame( 'oldvalue', constant( $name ), $name );
 				$this->assertEquals( $data, constant( $name ), $name );
 			}
 		}
@@ -138,14 +138,14 @@ class BlockTest extends TestCase {
 				eval( "\$data = $data;" ); // phpcs:ignore Squiz.PHP.Eval.Discouraged
 				$name = "test_var_block_{$b}_raw_{$d}";
 				$this->assertTrue( ( isset( ${$name} ) || is_null( ${$name} ) ), "\${$name}" );
-				$this->assertNotEquals( 'oldvalue', ${$name}, "\${$name}" );
+				$this->assertNotSame( 'oldvalue', ${$name}, "\${$name}" );
 				$this->assertEquals( $data, ${$name}, "\${$name}" );
 			}
 			// Strings
 			foreach ( self::$string_data as $d => $data ) {
 				$name = "test_var_block_{$b}_string_{$d}";
 				$this->assertTrue( ( isset( ${$name} ) || is_null( ${$name} ) ), "\${$name}" );
-				$this->assertNotEquals( 'oldvalue', ${$name}, "\${$name}" );
+				$this->assertNotSame( 'oldvalue', ${$name}, "\${$name}" );
 				$this->assertEquals( $data, ${$name}, "\${$name}" );
 			}
 		}

--- a/tests/4-MultilineTest.php
+++ b/tests/4-MultilineTest.php
@@ -37,7 +37,7 @@ EOF
 		require_once self::$test_config_path;
 
 		$this->assertTrue( defined( 'SECOND_CONSTANT' ), 'SECOND_CONSTANT not defined' );
-		$this->assertNotEquals( 'oldvalue', constant( 'SECOND_CONSTANT' ), 'SECOND_CONSTANT is still "oldvalue"' );
+		$this->assertNotSame( 'oldvalue', constant( 'SECOND_CONSTANT' ), 'SECOND_CONSTANT is still "oldvalue"' );
 		$this->assertEquals( 'newvalue', constant( 'SECOND_CONSTANT' ), 'SECOND_CONSTANT is not "newvalue"' );
 
 	}


### PR DESCRIPTION
It looks like `assertNotEquals` is doing a truthy comparison that causes the test to fail.

See https://github.com/wp-cli/wp-cli/issues/5764