### PR TITLE
Fix incorrect return type in docblock for get_value()

### DIFF
--- a/src/WPConfigTransformer.php
+++ b/src/WPConfigTransformer.php
@@ -89,7 +89,7 @@ class WPConfigTransformer {
 	 * @param string $type Config type (constant or variable).
 	 * @param string $name Config name.
 	 *
-	 * @return array
+	 * @return string|null
 	 */
 	public function get_value( $type, $name ) {
 		$wp_config_src = file_get_contents( $this->wp_config_path );


### PR DESCRIPTION
`WPConfigTransformer::get_value()` never returns an array, but array is the return type being hinted in the associated docblock. I suggest changing it to `string|null`. I'm not aware of a situation in which it can return anything else. Feel free to correct me if I'm wrong, but through testing with int, float, string, array, stdClass and undefined variables I haven't managed to get anything else out of it.