### PR TITLE
Prevent trailing commas in define() from being included in the extracted value

### DIFF
--- a/src/WPConfigTransformer.php
+++ b/src/WPConfigTransformer.php
@@ -292,7 +292,7 @@ class WPConfigTransformer {
 			}
 		}
 
-		preg_match_all( '/(?<=^|;|<\?php\s|<\?\s)(\h*define\s*\(\s*[\'"](\w*?)[\'"]\s*)(,\s*(\'\'|""|\'.*?[^\\\\]\'|".*?[^\\\\]"|.*?)\s*)((?:,\s*(?:true|false)\s*)?\)\s*;)/ims', $src, $constants );
+		preg_match_all( '/(?<=^|;|<\?php\s|<\?\s)(\h*define\s*\(\s*[\'"](\w*?)[\'"]\s*)(,\s*(\'\'|""|\'.*?[^\\\\]\'|".*?[^\\\\]"|.*?)\s*,?\s*)((?:,\s*(?:true|false)[,\s]*)?\)\s*;)/ims', $src, $constants );
 		preg_match_all( '/(?<=^|;|<\?php\s|<\?\s)(\h*\$(\w+)\s*=)(\s*(\'\'|""|\'.*?[^\\\\]\'|".*?[^\\\\]"|.*?)\s*;)/ims', $src, $variables );
 
 		if ( ! empty( $constants[0] ) && ! empty( $constants[1] ) && ! empty( $constants[2] ) && ! empty( $constants[3] ) && ! empty( $constants[4] ) && ! empty( $constants[5] ) ) {


### PR DESCRIPTION
The current regex does not support trailing commas in the define construct (To the point where it goes completely bonkers). I'd like to propose a minor change that will address this problem.

Using the following code:
```
<?php
require __DIR__ . "/vendor/autoload.php";
$c = new WPConfigTransformer(__DIR__ . '/wp-config.php');
foreach([ 'DB_NAME', 'DB_USER', 'DB_PASSWORD', 'DB_HOST' ] as $var) {
  var_dump($c->get_value('constant', $var));
}
```

`wp-config.php` is the example used in README.MD, but with a few modifications, specifically adding trailing commas with and without the third parameter:
```
define('DB_NAME', 'database_name_here',);
define('DB_HOST', 'localhost', true, );
```

The full example is provided here:
https://gist.github.com/SteenSchutt/ca4413bf3aad75f9eb57f2b2e2999004

Output with current version:
```
WARNING  Undefined array key "DB_USER" in src/WPConfigTransformer.php on line 108.
WARNING  Trying to access array offset on value of type null in src/WPConfigTransformer.php on line 108.

string(59) "'database_name_here',);

define('DB_USER', 'username_here'"
NULL
string(15) "'password_here'"
string(51) "'localhost', true, );


define('DB_CHARSET', 'utf8'"
```

Output with my changes:
```
string(20) "'database_name_here'"
string(15) "'username_here'"
string(15) "'password_here'"
string(11) "'localhost'"
```

I tried getting the tests to run so I could add to those as well, but I continuously ran my head against a wall, so I hope you can help by adding some fixtures/tests that can check this. As far as I can tell, everything else still matches as before.

The number of steps required to preg_match the config file appears to be basically the same as before as well.

Thank you for providing this class as a standalone package, it has been massively helpful :)