### PR TITLE
Replace DOS line endings with LF

### DIFF
--- a/src/WPConfigTransformer.php
+++ b/src/WPConfigTransformer.php
@@ -70,7 +70,7 @@ class WPConfigTransformer {
 			throw new Exception( 'Config file is empty.' );
 		}
 		// Normalize the newline to prevent an issue coming from OSX.
-		$this->wp_config_src = str_replace( array( "\n\r", "\r" ), "\n", $wp_config_src );
+		$this->wp_config_src = str_replace( array( "\r\n", "\n\r", "\r" ), "\n", $wp_config_src );
 		$this->wp_configs    = $this->parse_wp_config( $this->wp_config_src );
 
 		if ( ! isset( $this->wp_configs[ $type ] ) ) {

--- a/tests/5-UpdateMixedLineEndingsTest.php
+++ b/tests/5-UpdateMixedLineEndingsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use WP_CLI\Tests\TestCase;
+
+class UpdateMixedLineEndingsTest extends TestCase {
+	private static $test_config_path;
+	private static $test_config_lines;
+	private static $config_transformer;
+	public static function set_up_before_class() {
+		self::$test_config_lines = array(
+			"<?php\n",
+			"// this is a demo\r\n",
+			"define( 'DB_NAME', '' );\n",
+			"define( 'DB_HOST', '' );\r\n",
+			"define( 'DB_USER', '' );\n\r",
+			"define( 'DB_COLLATE', '');\n",
+		);
+		self::$test_config_path  = tempnam( sys_get_temp_dir(), 'wp-config' );
+		file_put_contents( self::$test_config_path, implode( '', self::$test_config_lines ) );
+		self::$config_transformer = new WPConfigTransformer( self::$test_config_path );
+	}
+	public static function tear_down_after_class() {
+		unlink( self::$test_config_path );
+	}
+	public function testMixedLineEndingsAreNormalized() {
+		$this->assertTrue( self::$config_transformer->update( 'constant', 'DB_HOST', 'demo' ) );
+		$this->assertTrue( self::$config_transformer->update( 'constant', 'DB_HOST', '' ) );
+
+		$modified_config_lines = file( self::$test_config_path );
+		$this->assertSame( array_map( 'trim', self::$test_config_lines ), array_map( 'trim', $modified_config_lines ) );
+	}
+}

--- a/tests/5-UpdateMixedLineEndingsTest.php
+++ b/tests/5-UpdateMixedLineEndingsTest.php
@@ -10,10 +10,21 @@ class UpdateMixedLineEndingsTest extends TestCase {
 		self::$test_config_lines = array(
 			"<?php\n",
 			"// this is a demo\r\n",
+			"\r\n",
+			"\r\n",
 			"define( 'DB_NAME', '' );\n",
 			"define( 'DB_HOST', '' );\r\n",
 			"define( 'DB_USER', '' );\n\r",
+			"\r\n",
+			"\n\r",
+			"\r",
+			"\r",
+			"\r\n",
 			"define( 'DB_COLLATE', '');\n",
+			"\n\r",
+			"\n\r",
+			"\r",
+			"\r",
 		);
 		self::$test_config_path  = tempnam( sys_get_temp_dir(), 'wp-config' );
 		file_put_contents( self::$test_config_path, implode( '', self::$test_config_lines ) );


### PR DESCRIPTION
DOS line endings are not currently stripped from the wp-config files, which results in extra lines being added to the modified file.

Fixes https://github.com/wp-cli/config-command/issues/160