### PR TITLE
Add read-only option for WPConfigTransformer

### DIFF
--- a/src/WPConfigTransformer.php
+++ b/src/WPConfigTransformer.php
@@ -38,14 +38,14 @@ class WPConfigTransformer {
 	 *
 	 * @param string $wp_config_path Path to a wp-config.php file.
 	 */
-	public function __construct( $wp_config_path ) {
+	public function __construct( $wp_config_path, $read_only = false ) {
 		$basename = basename( $wp_config_path );
 
 		if ( ! file_exists( $wp_config_path ) ) {
 			throw new Exception( "{$basename} does not exist." );
 		}
 
-		if ( ! is_writable( $wp_config_path ) ) {
+		if ( ! $read_only && ! is_writable( $wp_config_path ) ) {
 			throw new Exception( "{$basename} is not writable." );
 		}
 

--- a/tests/SetupTest.php
+++ b/tests/SetupTest.php
@@ -17,6 +17,12 @@ class SetupTest extends TestCase {
 		$config_transformer = new WPConfigTransformer( __DIR__ . '/fixtures/wp-config-not-writable.php' );
 	}
 
+	public function testFileNotWritableReadOnly() {
+		$this->expectNotToPerformAssertions();
+		chmod( __DIR__ . '/fixtures/wp-config-not-writable.php', 0444 );
+		$config_transformer = new WPConfigTransformer( __DIR__ . '/fixtures/wp-config-not-writable.php', true );
+	}
+
 	public function testFileEmpty() {
 		$this->expectException( Exception::class );
 		$this->expectExceptionMessage( 'Config file is empty.' );

--- a/tests/SetupTest.php
+++ b/tests/SetupTest.php
@@ -17,8 +17,10 @@ class SetupTest extends TestCase {
 		$config_transformer = new WPConfigTransformer( __DIR__ . '/fixtures/wp-config-not-writable.php' );
 	}
 
+	/**
+	 * @doesNotPerformAssertions
+	 */
 	public function testFileNotWritableReadOnly() {
-		$this->expectNotToPerformAssertions();
 		chmod( __DIR__ . '/fixtures/wp-config-not-writable.php', 0444 );
 		$config_transformer = new WPConfigTransformer( __DIR__ . '/fixtures/wp-config-not-writable.php', true );
 	}


### PR DESCRIPTION
Provides the option to skip checking that wp-config needs to be writable. Allows commands like `wp config has` to run on a read-only file system.

First part of addressing https://github.com/wp-cli/config-command/issues/184

WCUS Contributor Day [5985](https://github.com/wp-cli/wp-cli/issues/5985)

Note, `$this->expectNotToPerformAssertions();` is not supported by the version of PHPUnit used in our 5.6 tests, so using the `@doesNotPerformAssertions` annotation instead.