### PR TITLE
Add a `branch-alias` for `dev-main`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,11 @@
             "@behat"
         ]
     },
+    "extra": {
+        "branch-alias": {
+            "dev-main": "1.x-dev"
+        }
+    },
     "support": {
         "issues": "https://github.com/wp-cli/wp-config-transformer/issues"
     }


### PR DESCRIPTION
Resolves this error:

```
  Problem 1
    - Root composer.json requires wp-cli/config-command dev-main -> satisfiable by wp-cli/config-command[dev-main].
    - wp-cli/config-command dev-main requires wp-cli/wp-config-transformer ^1.4.0 -> satisfiable by wp-cli/wp-config-transformer[v1.4.0] from composer repo (https://repo.packagist.org) but wp-cli/wp-config-transformer[dev-main] from path repo (wp-config-transformer) has higher repository priority. The packages from the higher priority repository do not match your constraint and are therefore not installable. That repository is canonical so the lower priority repo's packages are not installable. See https://getcomposer.org/repoprio for details and assistance.
```