### PR TITLE
Remove DOTALL flag from parse_wp_config() regexes

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -45,11 +45,15 @@
 	</rule>
 
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound">
-		<exclude-pattern>tests/fixtures/wp-config-(?:example|not-writable)\.php$</exclude-pattern>
+		<exclude-pattern>tests/fixtures/wp-config-(?:example|not-writable|concat)\.php$</exclude-pattern>
+	</rule>
+
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound">
+		<exclude-pattern>tests/fixtures/wp-config-concat\.php$</exclude-pattern>
 	</rule>
 
 	<rule ref="WordPress.WP.GlobalVariablesOverride.Prohibited">
-		<exclude-pattern>tests/fixtures/wp-config-(?:example|not-writable)\.php$</exclude-pattern>
+		<exclude-pattern>tests/fixtures/wp-config-(?:example|not-writable|concat)\.php$</exclude-pattern>
 	</rule>
 
 	<rule ref="Squiz.PHP.CommentedOutCode.Found">

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -44,16 +44,14 @@
 		<exclude-pattern>tests/fixtures/wp-config-empty\.php$</exclude-pattern>
 	</rule>
 
-	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound">
-		<exclude-pattern>tests/fixtures/wp-config-(?:example|not-writable|concat)\.php$</exclude-pattern>
-	</rule>
+	<exclude-pattern>tests/fixtures/wp-config-concat\.php$</exclude-pattern>
 
-	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound">
-		<exclude-pattern>tests/fixtures/wp-config-concat\.php$</exclude-pattern>
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound">
+		<exclude-pattern>tests/fixtures/wp-config-(?:example|not-writable)\.php$</exclude-pattern>
 	</rule>
 
 	<rule ref="WordPress.WP.GlobalVariablesOverride.Prohibited">
-		<exclude-pattern>tests/fixtures/wp-config-(?:example|not-writable|concat)\.php$</exclude-pattern>
+		<exclude-pattern>tests/fixtures/wp-config-(?:example|not-writable)\.php$</exclude-pattern>
 	</rule>
 
 	<rule ref="Squiz.PHP.CommentedOutCode.Found">

--- a/src/WPConfigTransformer.php
+++ b/src/WPConfigTransformer.php
@@ -317,8 +317,8 @@ class WPConfigTransformer {
 			}
 		}
 
-		preg_match_all( '/(?<=^|;|<\?php\s|<\?\s)(\h*(?:defined\s*\(\s*[\'"][\w]+[\'"]\s*\)\s*(?:or|\|\|)\s*)?define\s*\(\s*[\'"](\w*?)[\'"]\s*)(,\s*(\'\'|""|\'.*?[^\\\\]\'|".*?[^\\\\]"|.*?)\s*,?\s*)((?:,\s*(?:true|false)[,\s]*)?\)\s*;)/im', $src, $constants );
-		preg_match_all( '/(?<=^|;|<\?php\s|<\?\s)(\h*\$(\w+)\s*=)(\s*(\'\'|""|\'.*?[^\\\\]\'|".*?[^\\\\]"|.*?)\s*;)/im', $src, $variables );
+		preg_match_all( '/(?<=^|;|<\?php\s|<\?\s)(\h*(?:defined\s*\(\s*[\'"][\w]+[\'"]\s*\)\s*(?:or|\|\|)\s*)?define\s*\(\s*[\'"](\w*?)[\'"]\s*)(,\s*(\'\'|""|\'[^\'\\\\]*(?:\\\\.[^\'\\\\]*)*\'|"[^"\\\\]*(?:\\\\.[^"\\\\]*)*"|.*?)\s*,?\s*)((?:,\s*(?:true|false)[,\s]*)?\)\s*;)/im', $src, $constants );
+		preg_match_all( '/(?<=^|;|<\?php\s|<\?\s)(\h*\$(\w+)\s*=)(\s*(\'\'|""|\'[^\'\\\\]*(?:\\\\.[^\'\\\\]*)*\'|"[^"\\\\]*(?:\\\\.[^"\\\\]*)*"|.*?)\s*;)/im', $src, $variables );
 
 		if ( ! empty( $constants[0] ) && ! empty( $constants[1] ) && ! empty( $constants[2] ) && ! empty( $constants[3] ) && ! empty( $constants[4] ) && ! empty( $constants[5] ) ) {
 			foreach ( $constants[2] as $index => $name ) {

--- a/src/WPConfigTransformer.php
+++ b/src/WPConfigTransformer.php
@@ -317,8 +317,8 @@ class WPConfigTransformer {
 			}
 		}
 
-		preg_match_all( '/(?<=^|;|<\?php\s|<\?\s)(\h*(?:defined\s*\(\s*[\'"][\w]+[\'"]\s*\)\s*(?:or|\|\|)\s*)?define\s*\(\s*[\'"](\w*?)[\'"]\s*)(,\s*(\'\'|""|\'.*?[^\\\\]\'|".*?[^\\\\]"|.*?)\s*,?\s*)((?:,\s*(?:true|false)[,\s]*)?\)\s*;)/ims', $src, $constants );
-		preg_match_all( '/(?<=^|;|<\?php\s|<\?\s)(\h*\$(\w+)\s*=)(\s*(\'\'|""|\'.*?[^\\\\]\'|".*?[^\\\\]"|.*?)\s*;)/ims', $src, $variables );
+		preg_match_all( '/(?<=^|;|<\?php\s|<\?\s)(\h*(?:defined\s*\(\s*[\'"][\w]+[\'"]\s*\)\s*(?:or|\|\|)\s*)?define\s*\(\s*[\'"](\w*?)[\'"]\s*)(,\s*(\'\'|""|\'.*?[^\\\\]\'|".*?[^\\\\]"|.*?)\s*,?\s*)((?:,\s*(?:true|false)[,\s]*)?\)\s*;)/im', $src, $constants );
+		preg_match_all( '/(?<=^|;|<\?php\s|<\?\s)(\h*\$(\w+)\s*=)(\s*(\'\'|""|\'.*?[^\\\\]\'|".*?[^\\\\]"|.*?)\s*;)/im', $src, $variables );
 
 		if ( ! empty( $constants[0] ) && ! empty( $constants[1] ) && ! empty( $constants[2] ) && ! empty( $constants[3] ) && ! empty( $constants[4] ) && ! empty( $constants[5] ) ) {
 			foreach ( $constants[2] as $index => $name ) {

--- a/src/WPConfigTransformer.php
+++ b/src/WPConfigTransformer.php
@@ -317,8 +317,8 @@ class WPConfigTransformer {
 			}
 		}
 
-		preg_match_all( '/(?<=^|;|<\?php\s|<\?\s)(\h*(?:defined\s*\(\s*[\'"][\w]+[\'"]\s*\)\s*(?:or|\|\|)\s*)?define\s*\(\s*[\'"](\w*?)[\'"]\s*)(,\s*(\'\'|""|\'[^\'\\\\]*(?:\\\\.[^\'\\\\]*)*\'|"[^"\\\\]*(?:\\\\.[^"\\\\]*)*"|[\s\S]*?)\s*,?\s*)((?:,\s*(?:true|false)[,\s]*)?\)\s*;)/im', $src, $constants );
-		preg_match_all( '/(?<=^|;|<\?php\s|<\?\s)(\h*\$(\w+)\s*=)(\s*(\'\'|""|\'[^\'\\\\]*(?:\\\\.[^\'\\\\]*)*\'|"[^"\\\\]*(?:\\\\.[^"\\\\]*)*"|[\s\S]*?)\s*;)/im', $src, $variables );
+		preg_match_all( '/(?<=^|;|<\?php\s|<\?\s)(\h*(?:defined\s*\(\s*[\'"][\w]+[\'"]\s*\)\s*(?:or|\|\|)\s*)?define\s*\(\s*[\'"](\w*?)[\'"]\s*)(,\s*(\'\'|""|\'[^\'\\\\]*(?:\\\\[\s\S][^\'\\\\]*)*\'|"[^"\\\\]*(?:\\\\[\s\S][^"\\\\]*)*"|[\s\S]*?)\s*,?\s*)((?:,\s*(?:true|false)[,\s]*)?\)\s*;)/im', $src, $constants );
+		preg_match_all( '/(?<=^|;|<\?php\s|<\?\s)(\h*\$(\w+)\s*=)(\s*(\'\'|""|\'[^\'\\\\]*(?:\\\\[\s\S][^\'\\\\]*)*\'|"[^"\\\\]*(?:\\\\[\s\S][^"\\\\]*)*"|[\s\S]*?)\s*;)/im', $src, $variables );
 
 		if ( ! empty( $constants[0] ) && ! empty( $constants[1] ) && ! empty( $constants[2] ) && ! empty( $constants[3] ) && ! empty( $constants[4] ) && ! empty( $constants[5] ) ) {
 			foreach ( $constants[2] as $index => $name ) {

--- a/src/WPConfigTransformer.php
+++ b/src/WPConfigTransformer.php
@@ -317,8 +317,8 @@ class WPConfigTransformer {
 			}
 		}
 
-		preg_match_all( '/(?<=^|;|<\?php\s|<\?\s)(\h*(?:defined\s*\(\s*[\'"][\w]+[\'"]\s*\)\s*(?:or|\|\|)\s*)?define\s*\(\s*[\'"](\w*?)[\'"]\s*)(,\s*(\'\'|""|\'[^\'\\\\]*(?:\\\\.[^\'\\\\]*)*\'|"[^"\\\\]*(?:\\\\.[^"\\\\]*)*"|.*?)\s*,?\s*)((?:,\s*(?:true|false)[,\s]*)?\)\s*;)/im', $src, $constants );
-		preg_match_all( '/(?<=^|;|<\?php\s|<\?\s)(\h*\$(\w+)\s*=)(\s*(\'\'|""|\'[^\'\\\\]*(?:\\\\.[^\'\\\\]*)*\'|"[^"\\\\]*(?:\\\\.[^"\\\\]*)*"|.*?)\s*;)/im', $src, $variables );
+		preg_match_all( '/(?<=^|;|<\?php\s|<\?\s)(\h*(?:defined\s*\(\s*[\'"][\w]+[\'"]\s*\)\s*(?:or|\|\|)\s*)?define\s*\(\s*[\'"](\w*?)[\'"]\s*)(,\s*(\'\'|""|\'[^\'\\\\]*(?:\\\\.[^\'\\\\]*)*\'|"[^"\\\\]*(?:\\\\.[^"\\\\]*)*"|[\s\S]*?)\s*,?\s*)((?:,\s*(?:true|false)[,\s]*)?\)\s*;)/im', $src, $constants );
+		preg_match_all( '/(?<=^|;|<\?php\s|<\?\s)(\h*\$(\w+)\s*=)(\s*(\'\'|""|\'[^\'\\\\]*(?:\\\\.[^\'\\\\]*)*\'|"[^"\\\\]*(?:\\\\.[^"\\\\]*)*"|[\s\S]*?)\s*;)/im', $src, $variables );
 
 		if ( ! empty( $constants[0] ) && ! empty( $constants[1] ) && ! empty( $constants[2] ) && ! empty( $constants[3] ) && ! empty( $constants[4] ) && ! empty( $constants[5] ) ) {
 			foreach ( $constants[2] as $index => $name ) {

--- a/tests/ConcatenationTest.php
+++ b/tests/ConcatenationTest.php
@@ -20,11 +20,11 @@ class ConcatenationTest extends TestCase {
 
 	public static function existsProvider() {
 		return array(
-			'concatenation variable itself'          => array( 'variable', 'do_redirect' ),
-			'variable after concatenation'           => array( 'variable', 'table_prefix' ),
-			'constant after concatenation variable'  => array( 'constant', 'DB_NAME' ),
-			'constant with multiline string value'   => array( 'constant', 'CUSTOM_CSS' ),
-			'variable after multiline string value'  => array( 'variable', 'after_multiline' ),
+			'concatenation variable itself'         => array( 'variable', 'do_redirect' ),
+			'variable after concatenation'          => array( 'variable', 'table_prefix' ),
+			'constant after concatenation variable' => array( 'constant', 'DB_NAME' ),
+			'constant with multiline string value'  => array( 'constant', 'CUSTOM_CSS' ),
+			'variable after multiline string value' => array( 'variable', 'after_multiline' ),
 		);
 	}
 

--- a/tests/ConcatenationTest.php
+++ b/tests/ConcatenationTest.php
@@ -9,7 +9,7 @@ class ConcatenationTest extends TestCase {
 	protected static $config_transformer;
 
 	public static function set_up_before_class() {
-		self::$config_path = __DIR__ . '/fixtures/wp-config-test-concat.php';
+		self::$config_path = __DIR__ . '/wp-config-test-concat.php';
 		copy( __DIR__ . '/fixtures/wp-config-concat.php', self::$config_path );
 		self::$config_transformer = new WPConfigTransformer( self::$config_path );
 	}
@@ -25,6 +25,9 @@ class ConcatenationTest extends TestCase {
 			'constant after concatenation variable' => array( 'constant', 'DB_NAME' ),
 			'constant with multiline string value'  => array( 'constant', 'CUSTOM_CSS' ),
 			'variable after multiline string value' => array( 'variable', 'after_multiline' ),
+			'multiline concatenation variable'      => array( 'variable', 'long_url' ),
+			'constant with multiline raw value'     => array( 'constant', 'ALLOWED_HOSTS' ),
+			'variable after multiline raw define'   => array( 'variable', 'after_array_define' ),
 		);
 	}
 

--- a/tests/ConcatenationTest.php
+++ b/tests/ConcatenationTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use WP_CLI\Tests\TestCase;
+
+class ConcatenationTest extends TestCase {
+
+	protected static $config_path;
+	protected static $config_transformer;
+
+	public static function set_up_before_class() {
+		self::$config_path = __DIR__ . '/fixtures/wp-config-test-concat.php';
+		copy( __DIR__ . '/fixtures/wp-config-concat.php', self::$config_path );
+		self::$config_transformer = new WPConfigTransformer( self::$config_path );
+	}
+
+	public static function tear_down_after_class() {
+		unlink( self::$config_path );
+	}
+
+	public function testVariableAfterConcatenationAssignmentExists() {
+		$this->assertTrue( self::$config_transformer->exists( 'variable', 'table_prefix' ), '$table_prefix should be found after a concatenation assignment' );
+	}
+
+	public function testConcatenationVariableItselfExists() {
+		$this->assertTrue( self::$config_transformer->exists( 'variable', 'do_redirect' ), '$do_redirect should be found' );
+	}
+
+	public function testConstantAfterConcatenationAssignmentExists() {
+		$this->assertTrue( self::$config_transformer->exists( 'constant', 'DB_NAME' ), 'DB_NAME should be found after a concatenation variable' );
+	}
+
+	public function testVariableAfterConcatenationHasCorrectValue() {
+		$this->assertSame( "'wp_'", self::$config_transformer->get_value( 'variable', 'table_prefix' ), '$table_prefix value should be wp_' );
+	}
+}

--- a/tests/ConcatenationTest.php
+++ b/tests/ConcatenationTest.php
@@ -42,7 +42,29 @@ class ConcatenationTest extends TestCase {
 		$this->assertTrue( self::$config_transformer->exists( $type, $name ), "{$label} should be found" );
 	}
 
-	public function testVariableAfterConcatenationHasCorrectValue() {
-		$this->assertSame( "'wp_'", self::$config_transformer->get_value( 'variable', 'table_prefix' ) );
+	public static function getValueProvider() {
+		return array(
+			'concatenation expression'     => array( 'variable', 'do_redirect', "'https://example.com' . \$_SERVER['REQUEST_URI']" ),
+			'simple variable after concat' => array( 'variable', 'table_prefix', "'wp_'" ),
+			'simple constant'              => array( 'constant', 'DB_NAME', "'test_db'" ),
+			'multiline string constant'    => array( 'constant', 'CUSTOM_CSS', "'body {\n  color: red;\n}'" ),
+			'multiline concat variable'    => array( 'variable', 'long_url', "'https://example.com'\n  . '/path'" ),
+			'multiline raw constant'       => array( 'constant', 'ALLOWED_HOSTS', "array(\n  'example.com',\n)" ),
+			'backslash-newline variable'   => array( 'variable', 'backslash_newline', "'line1\\\nline2'" ),
+		);
+	}
+
+	/**
+	 * @dataProvider getValueProvider
+	 */
+	#[DataProvider( 'getValueProvider' )] // phpcs:ignore PHPCompatibility.Attributes.NewAttributes.PHPUnitAttributeFound
+	public function testGetValue( $type, $name, $expected ) {
+		$this->assertSame( $expected, self::$config_transformer->get_value( $type, $name ) );
+	}
+
+	public function testUpdateMultilineEntry() {
+		self::$config_transformer->update( 'constant', 'CUSTOM_CSS', 'replaced' );
+		$this->assertSame( "'replaced'", self::$config_transformer->get_value( 'constant', 'CUSTOM_CSS' ) );
+		$this->assertTrue( self::$config_transformer->exists( 'variable', 'after_multiline' ), '$after_multiline should still exist after update' );
 	}
 }

--- a/tests/ConcatenationTest.php
+++ b/tests/ConcatenationTest.php
@@ -20,14 +20,16 @@ class ConcatenationTest extends TestCase {
 
 	public static function existsProvider() {
 		return array(
-			'concatenation variable itself'         => array( 'variable', 'do_redirect' ),
-			'variable after concatenation'          => array( 'variable', 'table_prefix' ),
-			'constant after concatenation variable' => array( 'constant', 'DB_NAME' ),
-			'constant with multiline string value'  => array( 'constant', 'CUSTOM_CSS' ),
-			'variable after multiline string value' => array( 'variable', 'after_multiline' ),
-			'multiline concatenation variable'      => array( 'variable', 'long_url' ),
-			'constant with multiline raw value'     => array( 'constant', 'ALLOWED_HOSTS' ),
-			'variable after multiline raw define'   => array( 'variable', 'after_array_define' ),
+			'concatenation variable itself'           => array( 'variable', 'do_redirect' ),
+			'variable after concatenation'            => array( 'variable', 'table_prefix' ),
+			'constant after concatenation variable'   => array( 'constant', 'DB_NAME' ),
+			'constant with multiline string value'    => array( 'constant', 'CUSTOM_CSS' ),
+			'variable after multiline string value'   => array( 'variable', 'after_multiline' ),
+			'multiline concatenation variable'        => array( 'variable', 'long_url' ),
+			'constant with multiline raw value'       => array( 'constant', 'ALLOWED_HOSTS' ),
+			'variable after multiline raw define'     => array( 'variable', 'after_array_define' ),
+			'backslash-newline in quoted string'      => array( 'variable', 'backslash_newline' ),
+			'variable after backslash-newline string' => array( 'variable', 'after_backslash_newline' ),
 		);
 	}
 

--- a/tests/ConcatenationTest.php
+++ b/tests/ConcatenationTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use WP_CLI\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ConcatenationTest extends TestCase {
 
@@ -17,27 +18,26 @@ class ConcatenationTest extends TestCase {
 		unlink( self::$config_path );
 	}
 
-	public function testVariableAfterConcatenationAssignmentExists() {
-		$this->assertTrue( self::$config_transformer->exists( 'variable', 'table_prefix' ), '$table_prefix should be found after a concatenation assignment' );
+	public static function existsProvider() {
+		return array(
+			'concatenation variable itself'          => array( 'variable', 'do_redirect' ),
+			'variable after concatenation'           => array( 'variable', 'table_prefix' ),
+			'constant after concatenation variable'  => array( 'constant', 'DB_NAME' ),
+			'constant with multiline string value'   => array( 'constant', 'CUSTOM_CSS' ),
+			'variable after multiline string value'  => array( 'variable', 'after_multiline' ),
+		);
 	}
 
-	public function testConcatenationVariableItselfExists() {
-		$this->assertTrue( self::$config_transformer->exists( 'variable', 'do_redirect' ), '$do_redirect should be found' );
-	}
-
-	public function testConstantAfterConcatenationAssignmentExists() {
-		$this->assertTrue( self::$config_transformer->exists( 'constant', 'DB_NAME' ), 'DB_NAME should be found after a concatenation variable' );
+	/**
+	 * @dataProvider existsProvider
+	 */
+	#[DataProvider( 'existsProvider' )] // phpcs:ignore PHPCompatibility.Attributes.NewAttributes.PHPUnitAttributeFound
+	public function testExists( $type, $name ) {
+		$label = ( 'variable' === $type ) ? "\${$name}" : $name;
+		$this->assertTrue( self::$config_transformer->exists( $type, $name ), "{$label} should be found" );
 	}
 
 	public function testVariableAfterConcatenationHasCorrectValue() {
-		$this->assertSame( "'wp_'", self::$config_transformer->get_value( 'variable', 'table_prefix' ), '$table_prefix value should be wp_' );
-	}
-
-	public function testMultilineStringValueExists() {
-		$this->assertTrue( self::$config_transformer->exists( 'constant', 'CUSTOM_CSS' ), 'CUSTOM_CSS with multiline string value should be found' );
-	}
-
-	public function testVariableAfterMultilineStringValueExists() {
-		$this->assertTrue( self::$config_transformer->exists( 'variable', 'after_multiline' ), '$after_multiline should be found after a multiline string constant' );
+		$this->assertSame( "'wp_'", self::$config_transformer->get_value( 'variable', 'table_prefix' ) );
 	}
 }

--- a/tests/ConcatenationTest.php
+++ b/tests/ConcatenationTest.php
@@ -32,4 +32,12 @@ class ConcatenationTest extends TestCase {
 	public function testVariableAfterConcatenationHasCorrectValue() {
 		$this->assertSame( "'wp_'", self::$config_transformer->get_value( 'variable', 'table_prefix' ), '$table_prefix value should be wp_' );
 	}
+
+	public function testMultilineStringValueExists() {
+		$this->assertTrue( self::$config_transformer->exists( 'constant', 'CUSTOM_CSS' ), 'CUSTOM_CSS with multiline string value should be found' );
+	}
+
+	public function testVariableAfterMultilineStringValueExists() {
+		$this->assertTrue( self::$config_transformer->exists( 'variable', 'after_multiline' ), '$after_multiline should be found after a multiline string constant' );
+	}
 }

--- a/tests/ConcatenationTest.php
+++ b/tests/ConcatenationTest.php
@@ -59,7 +59,10 @@ class ConcatenationTest extends TestCase {
 	 */
 	#[DataProvider( 'getValueProvider' )] // phpcs:ignore PHPCompatibility.Attributes.NewAttributes.PHPUnitAttributeFound
 	public function testGetValue( $type, $name, $expected ) {
-		$this->assertSame( $expected, self::$config_transformer->get_value( $type, $name ) );
+		// Normalize line endings — get_value() does not normalize, so on
+		// Windows the returned value will contain \r\n from the fixture file.
+		$actual = str_replace( "\r\n", "\n", self::$config_transformer->get_value( $type, $name ) );
+		$this->assertSame( $expected, $actual );
 	}
 
 	public function testUpdateMultilineEntry() {

--- a/tests/fixtures/wp-config-concat.php
+++ b/tests/fixtures/wp-config-concat.php
@@ -6,3 +6,9 @@ define( 'CUSTOM_CSS', 'body {
   color: red;
 }' );
 $after_multiline = 'found';
+$long_url = 'https://example.com'
+  . '/path';
+define( 'ALLOWED_HOSTS', array(
+  'example.com',
+) );
+$after_array_define = 'found';

--- a/tests/fixtures/wp-config-concat.php
+++ b/tests/fixtures/wp-config-concat.php
@@ -2,3 +2,7 @@
 $do_redirect  = 'https://example.com' . $_SERVER['REQUEST_URI'];
 $table_prefix = 'wp_';
 define( 'DB_NAME', 'test_db' );
+define( 'CUSTOM_CSS', 'body {
+  color: red;
+}' );
+$after_multiline = 'found';

--- a/tests/fixtures/wp-config-concat.php
+++ b/tests/fixtures/wp-config-concat.php
@@ -1,0 +1,4 @@
+<?php
+$do_redirect = 'https://example.com' . $_SERVER['REQUEST_URI'];
+$table_prefix = 'wp_';
+define( 'DB_NAME', 'test_db' );

--- a/tests/fixtures/wp-config-concat.php
+++ b/tests/fixtures/wp-config-concat.php
@@ -12,3 +12,6 @@ define( 'ALLOWED_HOSTS', array(
   'example.com',
 ) );
 $after_array_define = 'found';
+$backslash_newline = 'line1\
+line2';
+$after_backslash_newline = 'found';

--- a/tests/fixtures/wp-config-concat.php
+++ b/tests/fixtures/wp-config-concat.php
@@ -1,4 +1,4 @@
 <?php
-$do_redirect = 'https://example.com' . $_SERVER['REQUEST_URI'];
+$do_redirect  = 'https://example.com' . $_SERVER['REQUEST_URI'];
 $table_prefix = 'wp_';
 define( 'DB_NAME', 'test_db' );


### PR DESCRIPTION
## Summary

Fixes #63 — concatenation expressions like `$x = 'foo' . $bar;` caused `parse_wp_config()` to match across statement boundaries, making `exists()`, `get_value()`, and other methods fail to find entries that followed.

### Root cause

The old quoted-string patterns (`'.*?[^\\]'` / `".*?[^\\]"`) with the `/s` (DOTALL) flag could match from the opening quote of one statement all the way into a subsequent statement when the value wasn't a simple quoted string (e.g. contained concatenation operators).

### How the regex works now

The value-matching portion of each regex uses three alternation branches, tried left to right:

1. **Empty strings** — `''` or `""` (literal empty values)
2. **Quoted strings via unrolled loop** — `'[^'\\]*(?:\\[\s\S][^'\\]*)*'` (and the double-quote equivalent)
   - `[^'\\]*` matches any run of characters that aren't a quote or backslash (including newlines — so multiline string values work)
   - `(?:\\[\s\S][^'\\]*)*` matches escape sequences: a backslash followed by any character (including newline), then another run of non-quote/non-backslash characters. Repeats zero or more times.
   - This pattern is **self-terminating** — it stops exactly at the closing quote and cannot cross statement boundaries, which is the key property that fixes the original bug.
3. **Raw fallback** — `[\s\S]*?` matches everything else (function calls, arrays, ternaries, concatenation expressions) lazily up to the closing `)` or `;`. Uses `[\s\S]` instead of `.` so multiline raw expressions (e.g. multi-line array defines) still match without the `/s` flag.

The `/s` (DOTALL) flag is removed entirely. Newline matching is handled explicitly: `[\s\S]` where needed, and `[^'\\]`/`[^"\\]` character classes which inherently match newlines.

### What's tested

The `ConcatenationTest` covers:
- Concatenation expressions and entries after them (the original bug)
- Multiline string values and entries after them
- Multiline raw expressions (array defines, multi-line concatenation)
- Backslash-newline inside quoted strings
- `get_value()` correctness for all edge cases (captured value groups)
- `update()` on a multiline entry with post-update readback